### PR TITLE
[WIP] ベクタ画像アセットの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.0.1",
+  "version": "2.0.0-feature.0",
   "description": "Type definitions and utilities for game.json, the manifest file for Akashic Engine.",
   "main": "lib/index.js",
   "scripts": {
@@ -85,7 +85,7 @@
     ]
   },
   "dependencies": {
-    "@akashic/pdi-types": "~1.1.1"
+    "@akashic/pdi-types": "2.0.0-feature.0"
   },
   "optionalDependencies": {
     "es6-promise": "^4.2.8"
@@ -109,6 +109,7 @@
     "typescript": "^4.1.3"
   },
   "publishConfig": {
-    "@akashic:registry": "https://registry.npmjs.org/"
+    "@akashic:registry": "https://registry.npmjs.org/",
+    "tag": "feature"
   }
 }

--- a/src/AssetConfiguration.ts
+++ b/src/AssetConfiguration.ts
@@ -1,4 +1,4 @@
-import { AudioAssetHint, ImageAssetHint } from "@akashic/pdi-types";
+import { AudioAssetHint, ImageAssetHint, VectorImageAssetHint } from "@akashic/pdi-types";
 
 /**
  * アセット宣言
@@ -30,7 +30,8 @@ export type AssetConfiguration =
 	| ImageAssetConfigurationBase
 	| TextAssetConfigurationBase
 	| ScriptAssetConfigurationBase
-	| VideoAssetConfigurationBase;
+	| VideoAssetConfigurationBase
+	| VectorImageAssetConfigurationBase;
 
 /**
  * Assetの設定の共通部分。
@@ -170,4 +171,29 @@ export interface ScriptAssetConfigurationBase extends AssetConfigurationBase {
 	 * Assetの種類。
 	 */
 	type: "script";
+}
+
+/**
+ * VectorImageAssetの設定。
+ */
+export interface VectorImageAssetConfigurationBase extends AssetConfigurationBase {
+	/**
+	 * Assetの種類。
+	 */
+	type: "vector-image";
+
+	/**
+	 * 幅。
+	 */
+	width: number;
+
+	/**
+	 * 高さ。
+	 */
+	height: number;
+
+	/**
+	 * ヒント。
+	 */
+	hint?: VectorImageAssetHint;
 }


### PR DESCRIPTION
## このPullRequestが解決する内容
ベクタ画像のサポートのため `vector-image` のアセット種別を追加します。