### PR TITLE
feat: add ImageAssetConfigurationBase#slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.2.0
+* `ImageAssetConfigurationBase#slice` を追加
+
 ## 1.1.0
 * @akashic/pdi-types@1.3.0 に追従
 * `VectorImageAsset` の設定を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-configuration",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/pdi-types": "~1.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Type definitions and utilities for game.json, the manifest file for Akashic Engine.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AssetConfiguration.ts
+++ b/src/AssetConfiguration.ts
@@ -71,7 +71,7 @@ export interface AssetConfigurationBase extends AssetConfigurationCommonBase {
  * CommonAreaの短縮表記。
  * 各要素は順に CommonArea の x, y, width, height に読み替えられる。
  */
-export type ShortenedCommonArea = [number, number, number, number];
+export type CommonAreaShortened = [number, number, number, number];
 
 /**
  * ImageAssetの設定。
@@ -101,7 +101,7 @@ export interface ImageAssetConfigurationBase extends AssetConfigurationBase {
 	 * 切り出す領域。
 	 * 指定した場合、その部分だけの画像アセットとして扱う。
 	 */
-	slice?: CommonArea | ShortenedCommonArea;
+	slice?: CommonArea | CommonAreaShortened;
 }
 
 /**

--- a/src/AssetConfiguration.ts
+++ b/src/AssetConfiguration.ts
@@ -1,4 +1,4 @@
-import { AudioAssetHint, ImageAssetHint, VectorImageAssetHint } from "@akashic/pdi-types";
+import { AudioAssetHint, ImageAssetHint, VectorImageAssetHint, CommonArea } from "@akashic/pdi-types";
 
 /**
  * アセット宣言
@@ -55,7 +55,6 @@ export interface AssetConfigurationBase extends AssetConfigurationCommonBase {
 
 	/**
 	 * Assetを表すファイルのrequire解決用の仮想ツリーにおけるパス。
-	 * `type` が `"script"` の場合にのみ存在する。
 	 * 省略するとエンジンにより自動的に設定される。
 	 */
 	// エンジン開発者は `Game` オブジェクト作成前に、省略された `virtualPath` を補完する必要がある。
@@ -67,6 +66,12 @@ export interface AssetConfigurationBase extends AssetConfigurationCommonBase {
 	 */
 	global?: boolean;
 }
+
+/**
+ * CommonAreaの短縮表記。
+ * 各要素は順に CommonArea の x, y, width, height に読み替えられる。
+ */
+export type ShortenedCommonArea = [number, number, number, number];
 
 /**
  * ImageAssetの設定。
@@ -91,6 +96,12 @@ export interface ImageAssetConfigurationBase extends AssetConfigurationBase {
 	 * ヒント。akashic-engineが最適なパフォーマンスを発揮するための情報。
 	 */
 	hint?: ImageAssetHint;
+
+	/**
+	 * 切り出す領域。
+	 * 指定した場合、その部分だけの画像アセットとして扱う。
+	 */
+	slice?: CommonArea | ShortenedCommonArea;
 }
 
 /**


### PR DESCRIPTION
掲題どおり。
game.json で画像の一部をアセットとして扱えるようにする指定 `slice` プロパティを追加します。
大量に記述したくなる可能性を踏まえ、 `CommonArea` (`{ x, y, width, height }`) ではない短縮表記 `[x, y, width, height]` もサポートしておきます。
