### PR TITLE
feat: add GameConfiguration#maxPoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased changes
+## 1.8.0
 * `GameConfiguration` に `maxPoints` を追加
 
 ## 1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased changes
+* `GameConfiguration` に `maxPoints` を追加
+
 ## 1.6.0
 * `AudioAssetConfigurationBase` に `offset` を追加
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-configuration",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/pdi-types": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Type definitions and utilities for game.json, the manifest file for Akashic Engine.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AssetConfiguration.ts
+++ b/src/AssetConfiguration.ts
@@ -1,4 +1,4 @@
-import { AudioAssetHint, ImageAssetHint, VectorImageAssetHint, CommonArea } from "@akashic/pdi-types";
+import type { AudioAssetHint, ImageAssetHint, VectorImageAssetHint, CommonArea } from "@akashic/pdi-types";
 
 /**
  * アセット宣言

--- a/src/GameConfiguration.ts
+++ b/src/GameConfiguration.ts
@@ -76,6 +76,12 @@ export interface GameConfiguration {
 	 */
 	defaultSkippingScene?: "fast-forward" | "indicator" | "none";
 
+	/**
+	 * 同時にタップ可能な上限を指定。
+	 * 指定された数以上のタップが同時にされた場合、maxPointsを超えたタップ以降無効となる。
+	 */
+	maxPoints?: number;
+
 	environment?: Environment;
 }
 

--- a/src/GameConfiguration.ts
+++ b/src/GameConfiguration.ts
@@ -77,8 +77,8 @@ export interface GameConfiguration {
 	defaultSkippingScene?: "fast-forward" | "indicator" | "none";
 
 	/**
-	 * 同時にタップ可能な上限を指定。
-	 * 指定された数以上のタップが同時にされた場合、maxPointsを超えたタップ以降無効となる。
+	 * 同時にポイント可能な上限を指定。
+	 * 指定された数以上のポイントが同時にされた場合、maxPoints目以降のポイントは全て無効となる。
 	 */
 	maxPoints?: number;
 


### PR DESCRIPTION
### 概要
akashic-engineに同時タップ数の制限を設けるため、game.jsonに同時にタップできる最大数を意味する`"maxPoints"`を追加する対応を行いました。