### PR TITLE
fix: drop data from BinaryAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.11.1
+* `BinaryAssetConfigurationBase` から `data` を削除
+
 ## 1.11.0
 * @akashic/pdi-types@1.10.0 に追従
 * `BinaryAsset` の設定を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-configuration",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/pdi-types": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Type definitions and utilities for game.json, the manifest file for Akashic Engine.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AssetConfiguration.ts
+++ b/src/AssetConfiguration.ts
@@ -242,9 +242,4 @@ export interface BinaryAssetConfigurationBase extends AssetConfigurationBase {
 	 * Assetの種類。
 	 */
 	type: "binary";
-
-	/**
-	 * ファイル内容のバイト配列。
-	 */
-	data: ArrayBuffer;
 }


### PR DESCRIPTION
# このPullRequestが解決する内容
game.json に `BinaryAsset#data` の情報は不要だったため削除します。