### PR TITLE
v2.0.0; audioExtensionResolver の戻り値に "." を要求するように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.0
+* `extractAssetPath()` の `audioExtensionsResolver` の戻り値の拡張子に `"."` を要求するように
+
 ## 1.12.0
 * `makePathKeyObject()` を追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 2.0.0
-* `extractAssetPath()` の `audioExtensionsResolver` の戻り値の拡張子に `"."` を要求するように
+* `extractAssetPaths()` の `audioExtensionResolver` の戻り値の拡張子に `"."` を要求するように
 
 ## 1.12.0
 * `makePathKeyObject()` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-configuration",
-      "version": "1.12.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/pdi-types": "^1.11.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-configuration",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "description": "Type definitions and utilities for game.json, the manifest file for Akashic Engine.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/__tests__/extractAssetPaths.spec.ts
+++ b/src/__tests__/extractAssetPaths.spec.ts
@@ -15,9 +15,11 @@ describe("extractAssetPaths", () => {
 			},
 			globalScripts: ["./node_modules/foo/bar.js"]
 		};
+
 		const result = extractAssetPaths({ gameConfiguration });
 		expect(result).toEqual(["script/main.js", "script/mainScene.js", "image/chara.png", "./node_modules/foo/bar.js"]);
 	});
+
 	it("指定されたGameConfigurationに音声アセットが登録されている場合、指定された audioExtensionResolver に従って音声ファイルパスが取得できる", () => {
 		const gameConfiguration: GameConfiguration = {
 			width: 320,
@@ -29,10 +31,12 @@ describe("extractAssetPaths", () => {
 			},
 			globalScripts: ["./node_modules/foo/bar.js"]
 		};
-		const audioExtensionResolver = (_asset: AudioAssetConfigurationBase): string[] => ["m4a", "ogg", "aac"];
+
+		const audioExtensionResolver = (_asset: AudioAssetConfigurationBase): string[] => [".m4a", ".ogg", ".aac"];
 		const result = extractAssetPaths({ gameConfiguration, audioExtensionResolver });
 		expect(result).toEqual(["script/main.js", "audio/se.m4a", "audio/se.ogg", "audio/se.aac", "./node_modules/foo/bar.js"]);
 	});
+
 	it("audioExtensionResolver が指定されない場合、hint.extensionsに従って音声ファイルパスが取得できる", () => {
 		const gameConfiguration: GameConfiguration = {
 			width: 320,
@@ -40,13 +44,15 @@ describe("extractAssetPaths", () => {
 			main: "./script/main.js",
 			assets: {
 				main: { type: "script", path: "script/main.js", global: true },
-				se: { type: "audio", path: "audio/se", duration: 1000, systemId: "sound", hint: { extensions: ["m4a", "aac"] } }
+				se: { type: "audio", path: "audio/se", duration: 1000, systemId: "sound", hint: { extensions: [".m4a", ".aac"] } }
 			},
 			globalScripts: ["./node_modules/foo/bar.js"]
 		};
+
 		const result = extractAssetPaths({ gameConfiguration });
 		expect(result).toEqual(["script/main.js", "audio/se.m4a", "audio/se.aac", "./node_modules/foo/bar.js"]);
 	});
+
 	it("audioExtensionResolver が指定されず音声アセット情報にhint.extensionsが無い場合、oggとaacの音声ファイルパスが取得できる", () => {
 		const gameConfiguration: GameConfiguration = {
 			width: 320,
@@ -58,6 +64,7 @@ describe("extractAssetPaths", () => {
 			},
 			globalScripts: ["./node_modules/foo/bar.js"]
 		};
+
 		const result = extractAssetPaths({ gameConfiguration });
 		expect(result).toEqual(["script/main.js", "audio/se.ogg", "audio/se.aac", "./node_modules/foo/bar.js"]);
 	});

--- a/src/utils/extractAssetPaths.ts
+++ b/src/utils/extractAssetPaths.ts
@@ -2,11 +2,23 @@ import type { AssetConfiguration, AudioAssetConfigurationBase } from "../AssetCo
 import type { GameConfiguration } from "../GameConfiguration";
 
 interface ExtractAssetPathsParameterObject {
+	/**
+	 * ファイルパスを抜き出したい game.json の内容。
+	 */
 	gameConfiguration: GameConfiguration;
+
+	/**
+	 * オーディオアセットの拡張子を解決する関数。
+	 *
+	 * 渡されたアセット定義のファイルパスは、これが返した拡張子を加えたものとして扱われる。
+	 * 戻り値は "." 込みの拡張子の配列でなければならない。
+	 */
 	audioExtensionResolver?: (asset: AudioAssetConfigurationBase) => string[];
 }
 
-// 指定された GameConfiguration から全アセットと全globalScriptsのパスを取得する
+/**
+ * 指定された GameConfiguration から全アセットと全globalScriptsのパスを取得する
+ */
 export function extractAssetPaths(params: ExtractAssetPathsParameterObject): string[] {
 	const { assets, globalScripts } = params.gameConfiguration;
 	let paths: string[];
@@ -28,15 +40,8 @@ function extractPath(
 	audioExtensionResolver?: (asset: AudioAssetConfigurationBase) => string[]
 ): string | string[] {
 	if (asset.type === "audio") {
-		let extensions: string[];
-		if (audioExtensionResolver) {
-			extensions = audioExtensionResolver(asset);
-		} else if (asset.hint?.extensions) {
-			extensions = asset.hint.extensions;
-		} else {
-			extensions = ["ogg", "aac"]; // 後方互換性として指定
-		}
-		return extensions.map(ext => `${asset.path}.${ext}`);
+		const exts = audioExtensionResolver?.(asset) ?? asset.hint?.extensions ?? [".ogg", ".aac"];
+		return exts.map(ext => `${asset.path}${ext}`);
 	} else {
 		return asset.path;
 	}


### PR DESCRIPTION
掲題どおり。

従来 `"."` なしの拡張子が来るものと想定した実装になっていて、 `hint.extensions` (`"."` 込み (に後からした)) を使うパスでは `"."` が過剰になっていました。これを修正します。

このモジュールにとっては不具合修正ですが、利用者にとっては破壊的変更になるので major バージョンを上げます。

